### PR TITLE
fix name of the backed-up zsh settings

### DIFF
--- a/diagnostics.zsh
+++ b/diagnostics.zsh
@@ -204,7 +204,7 @@ function _omz_diag_dump_one_big_text() {
   # to help with diagnosing behavior differences between bash and zsh
   cfgfiles=( /etc/zshenv /etc/zprofile /etc/zshrc /etc/zlogin /etc/zlogout 
     $zdotdir/.zshenv $zdotdir/.zprofile $zdotdir/.zshrc $zdotdir/.zlogin $zdotdir/.zlogout
-    ~/.zsh-pre-oh-my-zsh
+    ~/.zshrc.pre-oh-my-zsh
     /etc/bashrc /etc/profile ~/.bashrc ~/.profile ~/.bash_profile ~/.bash_logout )
   command ls -lad $cfgfiles 2>&1
   builtin echo


### PR DESCRIPTION
The name of the configuration backup is `~/.zshrc.pre-oh-my-zsh`. See [my dump](https://gist.github.com/franklinyu/1ee2a70722af07314395/7bc402615f3ed5199f544fb2065fc015a01552bd#file-omz_diagdump_20150606-102403-txt-L277).
